### PR TITLE
Ux polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "winston": "^3.19.0"
       },
       "devDependencies": {
+        "baseline-browser-mapping": "^2.10.21",
         "eslint": "^9.39.1",
         "eslint-config-next": "16.0.7",
         "sass": "^1.94.2"
@@ -2746,13 +2747,16 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.0.tgz",
-      "integrity": "sha512-Mh++g+2LPfzZToywfE1BUzvZbfOY52Nil0rn9H1CPC5DJ7fX+Vir7nToBeoiSbB1zTNeGYbELEvJESujgGrzXw==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "winston": "^3.19.0"
   },
   "devDependencies": {
+    "baseline-browser-mapping": "^2.10.21",
     "eslint": "^9.39.1",
     "eslint-config-next": "16.0.7",
     "sass": "^1.94.2"

--- a/src/app/components/Footer.jsx
+++ b/src/app/components/Footer.jsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import footerLogo from "@/../public/images/AMT-footer-logo.png"
+import Reveal from './Reveal'
 
 const Footer = ({  }) => {
 
@@ -14,7 +15,7 @@ const Footer = ({  }) => {
                         </div>
                     </div>
 
-                    <div className='contact-block'>
+                    <Reveal className='contact-block' delay={150}>
                         <div className='sqs-block bottom-blocks'>
                             <h3>CONTACT</h3>
                             <div className='socials-wrapper'>
@@ -49,9 +50,9 @@ const Footer = ({  }) => {
                             </p>
                         </div>
 
-                    </div>
+                    </Reveal>
 
-                    <div className='archive-block'>
+                    <Reveal className='archive-block' delay={100}>
                         <div className='sqs-block bottom-blocks'>
                             <h3>ARCHIVE</h3>
                             <br />
@@ -64,9 +65,9 @@ const Footer = ({  }) => {
                                 <Link href={"https://www.albinamusictrust.org/about-the-archive"}>About The Archive</Link>
                             </p>
                         </div>
-                    </div>
+                    </Reveal>
 
-                    <div className='explore-block'>
+                    <Reveal className='explore-block' delay={50}>
                         <div className='sqs-block bottom-blocks'>
                             <h3>EXPLORE</h3>
                             <br />
@@ -82,9 +83,9 @@ const Footer = ({  }) => {
                                 <br />
                             </p>
                         </div>
-                    </div>
+                    </Reveal>
 
-                    <div className='support-block'>
+                    <Reveal className='support-block'>
                         <div className='sqs-block bottom-blocks'>
                             <h3>SUPPORT</h3>
                             <br/>
@@ -98,9 +99,9 @@ const Footer = ({  }) => {
                                 <br/>
                             </p>
                         </div>
-                    </div>
+                    </Reveal>
 
-                    <div className='footer-logo-block'>
+                    <Reveal className='footer-logo-block' delay={200}>
                         <div className='sqs-block'>
                             <div className='footer-logo-wrapper'>
                                 <Image
@@ -113,7 +114,7 @@ const Footer = ({  }) => {
                                 />
                             </div>
                         </div>
-                    </div>
+                    </Reveal>
                 </div>
             </div>
         </footer>

--- a/src/app/components/MainContent.jsx
+++ b/src/app/components/MainContent.jsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { startTransition, Suspense, useEffect, useState } from "react"
+import { AnimatePresence, motion } from "motion/react"
 import AlbinaCommArchive from "./AlbinaCommArchive";
 import DesktopSidebar from "./DesktopSidebar";
 import HeroLanding from "./HeroLanding";
 import { useSearchParams } from "next/navigation";
 import useHeaderHeight from "@/utils/useHeaderHeight";
+
+const EASE = [0.4, 0, 0.2, 1];
 
 const MainContent = ({ }) => {
   const [hasInteracted, setHasInteracted] = useState(false);
@@ -25,22 +28,36 @@ const MainContent = ({ }) => {
     }
   }, [params]);
 
+  const showHero = params.size < 1 && !hasInteracted;
+
   return (
     <div
       className="main-content-wrap"
       style={{ paddingTop: headerHeight }}
     >
       <Suspense fallback={null}>
-        { params.size < 1 && !hasInteracted ?
-          <HeroLanding
-            handleInteraction={handleInteraction}
-          />
-          :
-          <div className="archive-layout">
-            <DesktopSidebar />
-            <AlbinaCommArchive />
-          </div>
-        }
+        <AnimatePresence mode="wait" initial={false}>
+          {showHero ? (
+            <motion.div
+              key="hero"
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.18, ease: EASE }}
+            >
+              <HeroLanding handleInteraction={handleInteraction} />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="archive"
+              className="archive-layout"
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.28, ease: EASE }}
+            >
+              <DesktopSidebar />
+              <AlbinaCommArchive />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </Suspense>
     </div>
   )

--- a/src/app/components/Reveal.jsx
+++ b/src/app/components/Reveal.jsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useInView } from 'react-intersection-observer';
+
+export default function Reveal({ children, delay = 0, className = '' }) {
+  const { ref, inView } = useInView({ threshold: 0.1, triggerOnce: true });
+
+  const classes = ['reveal', inView && 'reveal--visible', className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      ref={ref}
+      className={classes}
+      style={delay ? { transitionDelay: `${delay}ms` } : undefined}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/components/ShowItem.jsx
+++ b/src/app/components/ShowItem.jsx
@@ -2,6 +2,7 @@
 
 import useHeaderHeight from "@/utils/useHeaderHeight"
 import InfoBox from "./InfoBox"
+import Reveal from "./Reveal"
 import dynamic from "next/dynamic"
 import Link from "next/link"
 
@@ -19,12 +20,12 @@ export default function ShowItem({ itemData }){
       <InfoBox
         item={itemData}
       />
-      <div className="copyright-wrapper">
+      <Reveal className="copyright-wrapper">
         <div>
           <div>For all rights holder inquiries, please contact us <Link href={"mailto:albinacommunityarchive@gmail.com"} target="_blank">here.</Link></div>
           <div>See <Link className="dev-policy-link" href={`/terms-of-use`}>Copyright, Terms of Use & Policies </Link>for more information. </div>
         </div>
-      </div>
+      </Reveal>
     </div>
   )
 }

--- a/src/app/styles/archive-item.scss
+++ b/src/app/styles/archive-item.scss
@@ -17,6 +17,12 @@
 }
 
 .cmpt-archive-item__thumb {
+  overflow: hidden;
+
+  img {
+    transition: transform 400ms cubic-bezier(.2, .6, .3, 1);
+  }
+
   background: #222222;
   max-width: 100%;
   display: flex;
@@ -148,6 +154,15 @@
 .cmpt-archive-item {
   animation: fadeIn .4s ease forwards;
   opacity: 0;
+  transition: transform 220ms cubic-bezier(.2, .6, .3, 1);
+
+  &:hover {
+    transform: translateY(-4px);
+
+    .cmpt-archive-item__thumb img {
+      transform: scale(1.03);
+    }
+  }
 }
 
 @keyframes fadeIn {

--- a/src/app/styles/archive.scss
+++ b/src/app/styles/archive.scss
@@ -255,3 +255,15 @@
     left: 0;
   }
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/app/styles/nav.scss
+++ b/src/app/styles/nav.scss
@@ -157,6 +157,28 @@
 
 .header-nav-item {
   margin-left: 2vw;
+
+  a {
+    position: relative;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: -2px;
+      left: 0;
+      width: 100%;
+      height: 1px;
+      background: currentColor;
+      transform: scaleX(0);
+      transform-origin: right;
+      transition: transform 250ms cubic-bezier(.4, 0, .2, 1);
+    }
+
+    &:hover::after {
+      transform: scaleX(1);
+      transform-origin: left;
+    }
+  }
 }
 
 .desktop-nav-cta {

--- a/src/app/styles/root-layout.scss
+++ b/src/app/styles/root-layout.scss
@@ -1,5 +1,27 @@
 @use "variables";
 
+@view-transition {
+  navigation: auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  ::view-transition-old(root) {
+    animation: 180ms ease-out both vt-fade-out;
+  }
+
+  ::view-transition-new(root) {
+    animation: 260ms ease-in both vt-fade-in;
+  }
+}
+
+@keyframes vt-fade-out {
+  to { opacity: 0; }
+}
+
+@keyframes vt-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+}
+
 .main-content-wrap {
   padding-left: calc(6vw - 11px);
   padding-right: calc(6vw - 11px);

--- a/src/app/styles/util.scss
+++ b/src/app/styles/util.scss
@@ -6,6 +6,25 @@
   min-height: 100vh;
 }
 
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition:
+    opacity 500ms cubic-bezier(.4, 0, .2, 1),
+    transform 500ms cubic-bezier(.4, 0, .2, 1);
+
+  &.reveal--visible {
+    opacity: 1;
+    transform: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
 .global-container {
   width: 100%;
   max-width: variables.$content-width;

--- a/src/utils/toggleFilterParam.js
+++ b/src/utils/toggleFilterParam.js
@@ -8,6 +8,7 @@ const toggleFilterParam = (
   const existing = params.getAll(key);
 
   params.delete(key);
+  params.delete("page");
 
   if (!existing.includes(value)) {
     [...existing, value].forEach(v => params.append(key, v));


### PR DESCRIPTION
## Summary

A polish pass focused on three areas: interactive micro-animations, page-to-page transition continuity, and scroll-driven reveals. All motion is gated by `prefers-reduced-motion`. No new runtime dependencies — Motion and `react-intersection-observer` were already in `package.json`.

### Archive card hover
Card lifts 4px on hover via `translateY` with a 220ms cubic-bezier. The thumbnail image scales to 1.03 independently at 400ms, contained by `overflow: hidden` on the thumb wrapper. The two transitions are on separate elements so they can use different durations without fighting.

### Desktop nav underline
Nav links get a 1px pseudo-element underline that slides in left-to-right on hover (`scaleX(0) → 1`, `transform-origin` swapping between `right` and `left`) at 250ms. No markup changes required.

### Hero → archive layout transition
`AnimatePresence mode="wait"` from Motion v12 replaces the hard state cut. The hero exits with `opacity: 0, y: -8` over 180ms before the archive enters at `opacity: 0, y: 12 → 1, 0` over 280ms. Both use `cubic-bezier(.4, 0, .2, 1)` to match the existing mobile menu timing. `initial={false}` on `AnimatePresence` prevents the archive from animating in on direct URL loads. The now-redundant CSS `animation` on `.archive-layout` was removed.

### Page transitions
`@view-transition { navigation: auto; }` enables native browser-handled cross-fades for all same-origin navigations (gallery → item detail, home → collections, etc.). Customized with `::view-transition-old/new(root)` pseudo-elements: old page fades out over 180ms, new page fades in with a subtle 8px upward translate over 260ms. Entire block is inside `@media (prefers-reduced-motion: no-preference)`. Degrades gracefully to instant navigation in Firefox and older Safari.

### Scroll-reveal system
New reusable `Reveal` client component using `useInView` (`triggerOnce: true`, 10% threshold). Accepts a `className` prop so it drops in as a direct replacement for grid-placement divs with no layout side effects. CSS handles the `opacity: 0 / translateY(16px)` initial state so there's no flash before hydration. Applied to all five footer grid blocks (0–150ms stagger) and the item detail copyright section. `prefers-reduced-motion: reduce` overrides both opacity and transform to show content immediately.

### Pagination reset on filter change
`params.delete("page")` added to `toggleFilterParam` so changing any filter always returns to page 1. Prevents the stale-page bug where applying a new filter while on page 4+ could yield zero results.

## Test plan
- [ ] Archive gallery: cards lift and thumbnail scales on hover
- [ ] Desktop nav: underline slides in on link hover, slides out on leave
- [ ] Home: clicking "ADVANCED SEARCH" fades the hero out before the archive grid fades in
- [ ] Home with URL params (e.g. `/?search=music`): archive loads directly with no entrance animation
- [ ] Navigate gallery → item detail → back: cross-fade transition plays
- [ ] Scroll to footer: blocks reveal with stagger; footer logo fades in last
- [ ] Item detail page: scroll to copyright line — it fades in on scroll
- [ ] Apply a filter from page 3+: returns to page 1
- [ ] Enable "Reduce motion" in OS settings: all animations disabled,