### PR TITLE
Page Number Preview to thumbnails

### DIFF
--- a/src/app/components/ArchiveItem.jsx
+++ b/src/app/components/ArchiveItem.jsx
@@ -13,9 +13,6 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
     }
     const validFormats = ["jpg", "jpeg", "png"];
 
-    console.log(item)
-
-    console.log(item.content_file_urls.length + item.medium_photo_urls.length)
     return (
         <>
             {

--- a/src/app/components/ArchiveItem.jsx
+++ b/src/app/components/ArchiveItem.jsx
@@ -13,6 +13,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
     }
     const validFormats = ["jpg", "jpeg", "png"];
 
+    console.log(item)
+
+    console.log(item.content_file_urls.length + item.medium_photo_urls.length)
     return (
         <>
             {
@@ -35,6 +38,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 loading="lazy"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -48,6 +54,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 loading="lazy"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -61,6 +70,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 className="cmpt-archive-item__icon"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -74,6 +86,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 alt={"Pdf icon"}
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -89,6 +104,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 loading="lazy"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -102,6 +120,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 className="cmpt-archive-item__icon"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -117,6 +138,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 loading="lazy"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -130,6 +154,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 className="cmpt-archive-item__icon"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -145,6 +172,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 loading="lazy"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 
@@ -160,6 +190,9 @@ const ArchiveItem = ({item, isFocused, focusedRef, index}) => {
                                 loading="lazy"
                                 draggable="false"
                             />
+                            <div className="cmpt-archive-item-pag">
+                                {item.content_file_urls?.length + item.medium_photo_urls?.length}
+                            </div>
                         </div>
                     )}
 

--- a/src/app/components/MediaCarousel.jsx
+++ b/src/app/components/MediaCarousel.jsx
@@ -14,7 +14,6 @@ import "swiper/css/pagination";
 
 
 const MediaCarousel = ({item}) => {
-    const [fileIndex, setFileIndex] = useState(0);
     const [carouselWidth, setCarouselWidth] = useState(0);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const containerRef = useRef();
@@ -214,7 +213,6 @@ const MediaCarousel = ({item}) => {
                         {/* ------------ VIDEO MEDIUM ------------ */}
                         {type === "video" &&
                             <video
-                            key={fileIndex}
                             controls controlsList="nodownload"
                             className="modalVideo"
                             >

--- a/src/app/styles/archive-item.scss
+++ b/src/app/styles/archive-item.scss
@@ -18,6 +18,7 @@
 
 .cmpt-archive-item__thumb {
   overflow: hidden;
+  position: relative;
 
   img {
     transition: transform 400ms cubic-bezier(.2, .6, .3, 1);
@@ -39,6 +40,15 @@
     width: 70%;
     padding: 10% 0;
     opacity: 0.3;
+  }
+
+  .cmpt-archive-item-pag {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background-color: black;
+    padding: 0.75em 1em;
+    border-radius: 30px;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds a pill-shaped badge to all archive item thumbnails displaying the total file count (`content_file_urls + medium_photo_urls`), giving users a quick visual indicator of how many pages/assets an item contains
- Styles the badge with `position: absolute` (bottom-right of thumbnail), a black background, and a pill border-radius
- Removes dead `fileIndex` state and its associated `key` prop from `MediaCarousel` that were no longer in use

## Test plan

- [x] Verify page count badge renders correctly on photo, printed material, article, audio, and film archive items
- [x] Confirm badge count matches the actual number of files associated with an item
- [x] Check badge positioning doesn't overlap with other thumbnail UI elements at various screen sizes
- [x] Confirm no regressions in `MediaCarousel` video playback after removing `fileIndex`
