### PR TITLE
InfoBox re-style

### DIFF
--- a/src/app/components/InfoBox.jsx
+++ b/src/app/components/InfoBox.jsx
@@ -1,3 +1,4 @@
+import ArchiveItemCommentModal from './ArchiveItemCommentModal'
 import sanitizeHtml from 'sanitize-html'
 import Link from "next/link"
 import { Fragment } from "react"
@@ -36,15 +37,34 @@ export default function InfoBox({ item }){
       }
       <MultiPane
         year={item.year}
-        notes={item.content_notes}
         locations={item.locations}
         tags={item.tags}
         commGroups={item.comm_groups}
         credit={item.credit}
-        cleanNotes={cleanNotes}
+      />
+      {item.content_notes.body &&
+        <div className='info-pane-wide'>
+          <div className="info-set">
+            <div className="is-label">NOTES:</div>
+            <div dangerouslySetInnerHTML={{ __html: cleanNotes }} />
+          </div>
+        </div>
+      }
+      {item.tags?.length > 0 &&
+        <div className='info-pane-wide'>
+          <div className="info-set">
+            <div className="is-label">TAG{item.tags.length > 1 ? "S" : ""}:</div>
+            {item.tags.map((i, idx) => (
+              <Fragment key={i.id} >
+                <Link href={`/?tags=${encodeURIComponent(i.name)}`}>{i.name}</Link>{idx < item.tags.length - 1 ? ", " : ""}
+              </Fragment>
+            ))}
+          </div>
+        </div>
+      }
+      <ArchiveItemCommentModal
         id={item.id}
         uid={item.uid}
-        title={item.title}
       />
     </div>
   )

--- a/src/app/components/MultiPane.jsx
+++ b/src/app/components/MultiPane.jsx
@@ -1,18 +1,12 @@
-import ArchiveItemCommentModal from "./ArchiveItemCommentModal"
 import Link from "next/link"
 import { Fragment } from "react"
 
 export default function MultiPane({
   year,
-  notes,
   locations,
   tags,
   commGroups,
   credit,
-  cleanNotes,
-  id,
-  uid,
-  title
 }) {
 
   return (
@@ -28,36 +22,6 @@ export default function MultiPane({
             ))}
           </div>
         }
-        {notes.body &&
-          <div className="info-set">
-            <div className="is-label">NOTES:</div>
-            <div dangerouslySetInnerHTML={{ __html: cleanNotes }} />
-          </div>
-        }
-        {tags?.length > 0 &&
-          <div className="info-set">
-            <div className="is-label">TAG{tags.length > 1 ? "S" : ""}:</div>
-            {tags.map((i, idx) => (
-              <Fragment key={i.id} >
-                <Link href={`/?tags=${encodeURIComponent(i.name)}`}>{i.name}</Link>{idx < tags.length - 1 ? ", " : ""}
-              </Fragment>
-            ))}
-          </div>
-        }
-        {year &&
-          <div className="info-set">
-            <div className="is-label">YEAR:</div>
-            {year}
-          </div>
-        }
-      </div>
-      <div className="right-col-info">
-        {credit?.length > 0 &&
-          <div className="info-set">
-            <div className="is-label">CREDIT:</div>
-            <span>{credit}</span>
-          </div>
-        }
         {locations?.length > 0 &&
           <div className="info-set">
             <div className="is-label">LOCATION{locations.length > 1 ? "S" : ""}:</div>
@@ -69,10 +33,20 @@ export default function MultiPane({
             ))}
           </div>
         }
-        <ArchiveItemCommentModal
-          id={id}
-          uid={uid}
-        />
+      </div>
+      <div className="right-col-info">
+        {credit?.length > 0 &&
+          <div className="info-set">
+            <div className="is-label">CREDIT:</div>
+            <span>{credit}</span>
+          </div>
+        }
+        {year &&
+          <div className="info-set">
+            <div className="is-label">YEAR:</div>
+            {year}
+          </div>
+        }
       </div>
     </div>
   )

--- a/src/app/styles/info-box.scss
+++ b/src/app/styles/info-box.scss
@@ -27,20 +27,24 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     border: solid white 1px;
+  }
 
-    .info-set {
-      margin-bottom: 8px;
-      padding: 10px 15px;
-      font-size: 10px;
+  .info-pane-wide {
+    border: solid white 1px;
+  }
 
-      @media (min-width: variables.$bp-lg) {
-        font-size: 12px;
-      }
+  .info-set {
+    margin-bottom: 8px;
+    padding: 10px 15px;
+    font-size: 10px;
 
-      .is-label{
-        // font-size: 10px;
-        margin-bottom: 4px;
-      }
+    @media (min-width: variables.$bp-lg) {
+      font-size: 12px;
+    }
+
+    .is-label{
+      // font-size: 10px;
+      margin-bottom: 4px;
     }
   }
 


### PR DESCRIPTION
# Refactor info pane: move Notes, Tags, and Comment CTA from MultiPane into InfoBox

## Summary

- Moved Notes, Tags, and the Comment CTA (`ArchiveItemCommentModal`) out of `MultiPane.jsx` and into `InfoBox.jsx`, giving them their own full-width `info-pane-wide` layout sections
- Cleaned up `MultiPane`'s props — removed `notes`, `cleanNotes`, `id`, `uid`, and `title` now that those concerns live in the parent
- Extracted `.info-set` styles out of the `.multi-pane` scope in `info-box.scss` so they can be shared across both the grid and full-width sections; added `.info-pane-wide` class with its own border styling

## Test plan

- [ ] Open an archive item with notes — confirm Notes section renders full-width below the multi-pane grid
- [ ] Open an archive item with one tag and one with multiple tags — confirm singular/plural label and link formatting
- [ ] Open an archive item without notes — confirm Notes section does not render
- [ ] Open an archive item without tags — confirm Tags section does not render
- [ ] Click the Comment CTA and confirm the modal opens correctly
- [ ] Verify no visual regressions on the multi-pane grid (Year, Credit, Locations, Comm Groups)