### PR TITLE
clear search params on new search and clear search

### DIFF
--- a/src/app/components/Search.jsx
+++ b/src/app/components/Search.jsx
@@ -18,6 +18,7 @@ const Search = ({ onHero }) => {
     e.preventDefault();
 
     if (!searchTerm || searchTerm.length < 1) return;
+    params.delete("page")
     params.set("search", searchTerm);
 
     push(`/?${params.toString()}`);
@@ -25,7 +26,8 @@ const Search = ({ onHero }) => {
 
   const clearTerm = (e) => {
     e.preventDefault();
-    setSearchTerm("")
+    setSearchTerm("");
+    params.delete("page");
     if (activeSearchTerm) {
       params.delete("search")
       const newParams = params.toString();


### PR DESCRIPTION
## Summary
- Clear the `page` query param whenever a new search is submitted, so a search no longer starts on a stale pagination page carried over from the previous listing.
- Clear the `page` query param when the search is cleared as well, for the same reason.

## Test plan
- [x] Navigate to a paginated page (e.g. `/?page=3`), submit a new search term, and confirm the resulting URL has no `page` param (starts on page 1 of results).
- [x] From a paginated + active search (e.g. `/?search=foo&page=3`), click the clear (X) button and confirm both `search` and `page` are removed from the URL.
- [x] Confirm existing pagination and search behavior (search-icon click, empty search no-op) still work as before.
